### PR TITLE
add base64 encoder

### DIFF
--- a/src/base64/Base64Encoder.wasm.ts
+++ b/src/base64/Base64Encoder.wasm.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2023 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+import { InWasm, IWasmInstance, OutputMode, OutputType, ExtractDefinition } from 'inwasm';
+
+const enum P8 {
+  LUT_P = 1024,
+  DST_P = 9216
+};
+
+const wasmEncode = InWasm({
+  name: 'encode',
+  type: OutputType.INSTANCE,
+  mode: OutputMode.SYNC,
+  srctype: 'Clang-C',
+  imports: {
+    env: { memory: new WebAssembly.Memory({ initial: 1 }) }
+  },
+  exports: {
+    enc: (src: number, length: number) => 0
+  },
+  compile: {
+    switches: ['-Wl,-z,stack-size=0', '-Wl,--stack-first']
+  },
+  code: `
+    static unsigned char PAD = '=';
+    unsigned short *LUT = (unsigned short *) ${P8.LUT_P};
+
+    void* enc(unsigned char *src, int length) {
+      unsigned char *dst = (unsigned char *) ${P8.DST_P};
+
+      int pad = length % 3;
+      length -= pad;
+
+      unsigned char *src_end3 = src + length;
+      unsigned int accu;
+
+      // 4x loop unrolling (~25% speedup)
+      unsigned char *src_end12 = src_end3 - 12;
+      while (src < src_end12) {
+        accu = src[0] << 16 | src[1] << 8 | src[2];
+        *((unsigned short *) dst) = LUT[ accu >> 12 ];
+        *((unsigned short *) (dst+2)) = LUT[ accu & 0xFFF ];
+
+        accu = src[3] << 16 | src[4] << 8 | src[5];
+        *((unsigned short *) (dst+4)) = LUT[ accu >> 12 ];
+        *((unsigned short *) (dst+6)) = LUT[ accu & 0xFFF ];
+
+        accu = src[6] << 16 | src[7] << 8 | src[8];
+        *((unsigned short *) (dst+8)) = LUT[ accu >> 12 ];
+        *((unsigned short *) (dst+10)) = LUT[ accu & 0xFFF ];
+
+        accu = src[9] << 16 | src[10] << 8 | src[11];
+        *((unsigned short *) (dst+12)) = LUT[ accu >> 12 ];
+        *((unsigned short *) (dst+14)) = LUT[ accu & 0xFFF ];
+
+        src += 12;
+        dst += 16;
+      }
+
+      while (src < src_end3) {
+        accu = src[0] << 16 | src[1] << 8 | src[2];
+        *((unsigned short *) dst) = LUT[ accu >> 12 ];
+        *((unsigned short *) (dst+2)) = LUT[ accu & 0xFFF ];
+        src += 3;
+        dst += 4;
+      }
+
+      if (pad == 2) {
+        accu = src[0] << 8 | src[1];
+        accu <<= 2;
+        *dst++ = LUT[accu >> 12] >> 8;
+        *dst++ = LUT[(accu >> 6) & 0x3F] >> 8;
+        *dst++ = LUT[accu & 0x3F] >> 8;
+        *dst++ = PAD;
+      } else if (pad == 1) {
+        accu = src[0];
+        accu <<= 4;
+        *dst++ = LUT[accu >> 6] >> 8;
+        *dst++ = LUT[accu & 0x3F] >> 8;
+        *dst++ = PAD;
+        *dst++ = PAD;
+      }
+
+      return dst;
+    }
+    `
+});
+
+type B64Encode = ExtractDefinition<ReturnType<typeof wasmEncode>>;
+
+// base64 map
+const MAP = new Uint8Array(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    .split('')
+    .map(el => el.charCodeAt(0))
+);
+
+const LUT = new Uint16Array(4096);
+for (let i = 0; i < MAP.length; ++i) {
+  const ii = i * 64;
+  for (let k = 0; k < MAP.length; ++k) {
+    LUT[ii + k] = MAP[k] << 8 | MAP[i];
+  }
+}
+
+
+/**
+ * Base64 Encoder
+ *
+ * Other than the decoder, the encoder does not work chunkwise.
+ * To simulate chunkwise encoding, split the data source in multiples of 3 bytes
+ * and concat the output afterwards.
+ *
+ * The implementation uses a 16-bit LUT to map 12 input bits to 2 base64 digits
+ * roughly doubling the throughput compared to a simple scalar implementation.
+ */
+export default class Base64Encoder {
+  private _inst!: IWasmInstance<B64Encode>;
+  private _mem!: WebAssembly.Memory;
+  private _d!: Uint8Array;
+
+  constructor(public keepSize: number) {}
+
+  /**
+   * Encode bytes in `d` as base64.
+   * Returns encoded byte array (borrowed).
+   */
+  public encode(d: Uint8Array): Uint8Array {
+    const bytes = Math.ceil(d.length * 1.4) + P8.DST_P;
+    if (!this._inst) {
+      this._mem = new WebAssembly.Memory({ initial: Math.ceil(bytes / 65536) });
+      (new Uint16Array(this._mem.buffer)).set(LUT, P8.LUT_P/2);
+      this._inst = wasmEncode({ env: { memory: this._mem }});
+    } else if (this._mem.buffer.byteLength < bytes) {
+      this._mem.grow(Math.ceil((bytes - this._mem.buffer.byteLength) / 65536));
+      this._d = null!;
+    }
+    if (!this._d) {
+      this._d = new Uint8Array(this._mem.buffer);
+    }
+    // put src data at the end of memory, also align to 256
+    const chunkP = (this._mem.buffer.byteLength - d.length) & ~0xFF;
+    this._d.set(d, chunkP);
+    const end = this._inst.exports.enc(chunkP, d.length);
+    return this._d.subarray(P8.DST_P, end);
+  }
+
+  /**
+   * Release memory conditionally based on `keepSize`.
+   * If memory gets released, also the wasm instance will be freed and recreated on next `encode`,
+   * otherwise the instance will be reused.
+   */
+  public release(): void {
+    if (!this._inst) return;
+    if (this._mem.buffer.byteLength > this.keepSize) {
+      this._inst = this._d = this._mem = null!;
+    }
+  }
+}

--- a/src/base64/base64.benchmark.ts
+++ b/src/base64/base64.benchmark.ts
@@ -1,5 +1,6 @@
 import { ThroughputRuntimeCase, perfContext } from 'xterm-benchmark';
 import Base64Decoder from './Base64Decoder.wasm';
+import Base64Encoder from './Base64Encoder.wasm';
 
 // eslint-disable-next-line
 declare const Buffer: any;
@@ -21,60 +22,114 @@ const b4096  = toBytes(d4096);
 const b65536 = toBytes(d65536);
 const b1M    = toBytes(d1M);
 const dec = new Base64Decoder(4000000);
-
+const enc = new Base64Encoder(4000000);
 
 const RUNS = 100;
 
-perfContext('Base64', () => {
+perfContext('Base64 - decode', () => {
   perfContext('Node - Buffer', () => {
-    new ThroughputRuntimeCase('decode - 256', () => {
+    new ThroughputRuntimeCase('256', () => {
       Buffer.from(d256, 'base64');
       return { payloadSize: d256.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
-    new ThroughputRuntimeCase('decode - 4096', () => {
+    new ThroughputRuntimeCase('4096', () => {
       Buffer.from(d4096, 'base64');
       return { payloadSize: d4096.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
-    new ThroughputRuntimeCase('decode - 65536', () => {
+    new ThroughputRuntimeCase('65536', () => {
       Buffer.from(d65536, 'base64');
       return { payloadSize: d65536.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
-    new ThroughputRuntimeCase('decode - 1048576', () => {
+    new ThroughputRuntimeCase('1048576', () => {
       Buffer.from(d1M, 'base64');
       return { payloadSize: d1M.length };
     }, { repeat: RUNS }).showAverageThroughput();
   });
 
   perfContext('Base64Decoder', () => {
-    new ThroughputRuntimeCase('decode - 256', () => {
+    new ThroughputRuntimeCase('256', () => {
       dec.init(192);
       dec.put(b256, 0, b256.length);
       dec.end();
       return { payloadSize: b256.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
-    new ThroughputRuntimeCase('decode - 4096', () => {
+    new ThroughputRuntimeCase('4096', () => {
       dec.init(3072);
       dec.put(b4096, 0, b4096.length);
       dec.end();
       return { payloadSize: b4096.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
-    new ThroughputRuntimeCase('decode - 65536', () => {
+    new ThroughputRuntimeCase('65536', () => {
       dec.init(49152);
       dec.put(b65536, 0, b65536.length);
       dec.end();
       return { payloadSize: b65536.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
-    new ThroughputRuntimeCase('decode - 1048576', () => {
+    new ThroughputRuntimeCase('1048576', () => {
       dec.init(786432);
       dec.put(b1M, 0, b1M.length);
       dec.end();
       return { payloadSize: b1M.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+  });
+});
+
+perfContext('Base64 - encode', () => {
+  perfContext('Node - Buffer', () => {
+    new ThroughputRuntimeCase('256', () => {
+      const data = b256.subarray(0, 192);
+      Buffer.from(data).toString('base64');
+      return { payloadSize: data.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+
+    new ThroughputRuntimeCase('4096', () => {
+      const data = b4096.subarray(0, 3072);
+      Buffer.from(data).toString('base64');
+      return { payloadSize: data.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+
+    new ThroughputRuntimeCase('65536', () => {
+      const data = b65536.subarray(0, 49152);
+      Buffer.from(data).toString('base64');
+      return { payloadSize: data.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+
+    new ThroughputRuntimeCase('1048576', () => {
+      const data = b1M.subarray(0, 786432);
+      Buffer.from(data).toString('base64');
+      return { payloadSize: data.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+  });
+  
+  perfContext('Base64Encoder', () => {
+    new ThroughputRuntimeCase('256', () => {
+      const data = b256.subarray(0, 192);
+      enc.encode(data);
+      return { payloadSize: data.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+
+    new ThroughputRuntimeCase('4096', () => {
+      const data = b4096.subarray(0, 3072);
+      enc.encode(data);
+      return { payloadSize: data.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+
+    new ThroughputRuntimeCase('65536', () => {
+      const data = b65536.subarray(0, 49152);
+      enc.encode(data);
+      return { payloadSize: data.length };
+    }, { repeat: RUNS }).showAverageThroughput();
+
+    new ThroughputRuntimeCase('1048576', () => {
+      const data = b1M.subarray(0, 786432);
+      enc.encode(data);
+      return { payloadSize: data.length };
     }, { repeat: RUNS }).showAverageThroughput();
   });
 });


### PR DESCRIPTION
@Tyriar

Added a base64 encoder implementation. It is reasonably fast (around the speed of nodejs' base64 impl, or even faster), and like 8-10x faster than `btoa`. No simd though, as safari is still pretty fresh with their wasm-simd rollout (happened in April).

In case you wonder - gonna need a base64 encoder for the image serialization later on...