### PR TITLE
base64 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ in your source code (example showing base64 decoder):
 ```typescript
 import Base64Decoder from 'xterm-wasm-parts/lib/base64/Base64Decoder.wasm';
 const b64Decoder = new Base64Decoder(123);   // keep memory if below 123 bytes
+...
 b64Decoder.init(3);                          // init decoder for 3 bytes (pulls wasm instance)
 const data = new Uint8Array([65,65,65,65]);
-b64Decoder.put(data, 0, 4);                  // == AAAA == \x00\x00\x00 decoded
+b64Decoder.put(data);                        // == AAAA == \x00\x00\x00 decoded
 b64Decoder.end();                            // end of chunk inputs
 b64Decoder.data8;                            // --> Uint8Array(3) [ 0, 0, 0 ] == \x00\x00\x00
 b64Decoder.release();                        // release memory if 123 exceeded

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mocha lib/**/*.test.js",
     "start": "npm run package && http-server",
     "build": "tsc -p . && inwasm 'lib/**/*.wasm.js'",
+    "watch": "tsc -w & inwasm -w 'lib/**/*.wasm.js' & wait",
     "benchmark": "xterm-benchmark lib/**/*.benchmark.js",
     "package": "npm run build",
     "prepublishOnly": "npm run package"

--- a/src/base64/Base64Decoder.wasm.ts
+++ b/src/base64/Base64Decoder.wasm.ts
@@ -252,8 +252,7 @@ const wasmDecode = InWasm({
 // });
 
 // FIXME: currently broken in inwasm
-type ExtractDefinition<Type> = Type extends () => IWasmInstance<infer X> ? X : never;
-type DecodeDefinition = ExtractDefinition<typeof wasmDecode>;
+type WasmDecodeType = ReturnType<typeof wasmDecode>;
 
 // base64 map
 const MAP = new Uint8Array(
@@ -286,7 +285,7 @@ const EMPTY = new Uint8Array(0);
 export default class Base64Decoder {
   private _d!: Uint8Array;
   private _m32!: Uint32Array;
-  private _inst!: IWasmInstance<DecodeDefinition>;
+  private _inst!: WasmDecodeType;
   private _mem!: WebAssembly.Memory;
 
   constructor(public keepSize: number) {}

--- a/src/base64/Base64Decoder.wasm.ts
+++ b/src/base64/Base64Decoder.wasm.ts
@@ -114,158 +114,154 @@ const wasmDecode = InWasm({
     `
 });
 
-// SIMD version - commented out for now due to missing Safari support
-// const wasmDecode = InWasm({
-//   name: 'decode',
-//   type: OutputType.INSTANCE,
-//   mode: OutputMode.SYNC,
-//   srctype: 'Clang-C',
-//   imports: {
-//     env: { memory: new WebAssembly.Memory({ initial: 1 }) }
-//   },
-//   exports: {
-//     dec: () => 0,
-//     end: () => 0
-//   },
-//   compile: {
-//     switches: ['-msimd128', '-Wl,-z,stack-size=0', '-Wl,--stack-first']
-//   },
-//   code: `
-//     #include <wasm_simd128.h>
-//     typedef struct {
-//       unsigned int wp;
-//       unsigned int sp;
-//       unsigned int dp;
-//       unsigned int e_size;
-//       unsigned int b_size;
-//       unsigned int dummy[3];
-//       unsigned char data[0];
-//     } State;
-//
-//     unsigned int *D0 = (unsigned int *) ${P32.D0*4};
-//     unsigned int *D1 = (unsigned int *) ${P32.D1*4};
-//     unsigned int *D2 = (unsigned int *) ${P32.D2*4};
-//     unsigned int *D3 = (unsigned int *) ${P32.D3*4};
-//     State *state = (State *) ${P32.STATE*4};
-//
-//     #define packed_byte(x) wasm_i8x16_splat((char) x)
-//     #define packed_dword(x) wasm_i32x4_splat(x)
-//     #define masked(x, mask) wasm_v128_and(x, wasm_i32x4_splat(mask))
-//
-//     int dec4() {
-//       unsigned int nsp = (state->wp - 1) & ~3;
-//       unsigned char *src = state->data + state->sp;
-//       unsigned char *end = state->data + nsp;
-//       unsigned char *dst = state->data + state->dp;
-//       unsigned int accu;
-//
-//       while (src < end) {
-//         if ((accu = D0[src[0]] | D1[src[1]] | D2[src[2]] | D3[src[3]]) >> 24) return 1;
-//         *((unsigned int *) dst) = accu;
-//         dst += 3;
-//         src += 4;
-//       }
-//       state->sp = nsp;
-//       state->dp = dst - state->data;
-//       return 0;
-//     }
-//
-//     int dec() {
-//       unsigned int nsp = (state->wp - 1) & ~15;
-//       unsigned char *src = state->data + state->sp;
-//       unsigned char *end = state->data + nsp;
-//       unsigned char *dst = state->data + state->dp;
-//       unsigned int accu;
-//
-//       v128_t err = wasm_i8x16_splat(0);
-//
-//       while (src < end) {
-//         v128_t data = wasm_v128_load((v128_t *) src);
-//
-//         // wasm-simd rewrite of http://0x80.pl/notesen/2016-01-17-sse-base64-decoding.html#vector-lookup-pshufb
-//         const v128_t higher_nibble = wasm_u32x4_shr(data, 4) & packed_byte(0x0f);
-//         const char linv = 1;
-//         const char hinv = 0;
-//
-//         const v128_t lower_bound_LUT = wasm_i8x16_make(
-//             /* 0 */ linv, /* 1 */ linv, /* 2 */ 0x2b, /* 3 */ 0x30,
-//             /* 4 */ 0x41, /* 5 */ 0x50, /* 6 */ 0x61, /* 7 */ 0x70,
-//             /* 8 */ linv, /* 9 */ linv, /* a */ linv, /* b */ linv,
-//             /* c */ linv, /* d */ linv, /* e */ linv, /* f */ linv
-//         );
-//         const v128_t upper_bound_LUT = wasm_i8x16_make(
-//             /* 0 */ hinv, /* 1 */ hinv, /* 2 */ 0x2b, /* 3 */ 0x39,
-//             /* 4 */ 0x4f, /* 5 */ 0x5a, /* 6 */ 0x6f, /* 7 */ 0x7a,
-//             /* 8 */ hinv, /* 9 */ hinv, /* a */ hinv, /* b */ hinv,
-//             /* c */ hinv, /* d */ hinv, /* e */ hinv, /* f */ hinv
-//         );
-//         // the difference between the shift and lower bound
-//         const v128_t shift_LUT = wasm_i8x16_make(
-//             /* 0 */ 0x00,        /* 1 */ 0x00,        /* 2 */ 0x3e - 0x2b, /* 3 */ 0x34 - 0x30,
-//             /* 4 */ 0x00 - 0x41, /* 5 */ 0x0f - 0x50, /* 6 */ 0x1a - 0x61, /* 7 */ 0x29 - 0x70,
-//             /* 8 */ 0x00,        /* 9 */ 0x00,        /* a */ 0x00,        /* b */ 0x00,
-//             /* c */ 0x00,        /* d */ 0x00,        /* e */ 0x00,        /* f */ 0x00
-//         );
-//
-//         const v128_t upper_bound = wasm_i8x16_swizzle(upper_bound_LUT, higher_nibble);
-//         const v128_t lower_bound = wasm_i8x16_swizzle(lower_bound_LUT, higher_nibble);
-//
-//         const v128_t below = wasm_i8x16_lt(data, lower_bound);
-//         const v128_t above = wasm_i8x16_gt(data, upper_bound);
-//         const v128_t eq_2f = wasm_i8x16_eq(data, packed_byte(0x2f));
-//
-//         // in_range = not (below or above) or eq_2f
-//         // outside  = not in_range = below or above and not eq_2f (from deMorgan law)
-//         const v128_t outside = wasm_v128_andnot(eq_2f, above | below);
-//         err = wasm_v128_or(err, outside);
-//
-//         const v128_t shift  = wasm_i8x16_swizzle(shift_LUT, higher_nibble);
-//         const v128_t t0     = wasm_i8x16_add(data, shift);
-//         v128_t v = wasm_i8x16_add(t0, wasm_v128_and(eq_2f, packed_byte(-3)));
-//
-//         // pack bytes
-//         const v128_t ca = masked(v, 0x003f003f);
-//         const v128_t db = masked(v, 0x3f003f00);
-//         const v128_t t00 = wasm_v128_or(wasm_u32x4_shr(db, 8), wasm_i32x4_shl(ca, 6));
-//         v128_t res = wasm_v128_or(wasm_u32x4_shr(t00, 16), wasm_i32x4_shl(t00, 12));
-//         res = wasm_i8x16_swizzle(res, wasm_i8x16_const(2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, 16, 16, 16, 16));
-//
-//         wasm_v128_store((v128_t *) dst, res);
-//         dst += 12;
-//         src += 16;
-//       }
-//
-//       if (wasm_i8x16_bitmask(err) != 0) return 1;
-//
-//       state->sp = nsp;
-//       state->dp = dst - state->data;
-//       return 0;
-//     }
-//
-//     int end() {
-//       int rem = state->wp - state->sp;
-//       if (rem > 4 && dec4()) return 1;
-//       rem = state->wp - state->sp;
-//       if (rem < 2) return 1;
-//
-//       unsigned char *src = state->data + state->sp;
-//       unsigned int accu = D0[src[0]] | D1[src[1]];
-//       int dp = 1;
-//       if (rem > 2 && src[2] != 61) {
-//         accu |= D2[src[2]];
-//         dp++;
-//       }
-//       if (rem == 4 && src[3] != 61) {
-//         accu |= D3[src[3]];
-//         dp++;
-//       }
-//       if (accu >> 24) return 1;
-//       *((unsigned int *) (state->data + state->dp)) = accu;
-//       state->dp += dp;
-//       return state->dp != state->b_size;
-//     }
-//     `
-// });
+// SIMD version (~35% faster) - commented out for now due to missing Safari support
+/*
+const wasmDecode = InWasm({
+  name: 'decode',
+  type: OutputType.INSTANCE,
+  mode: OutputMode.SYNC,
+  srctype: 'Clang-C',
+  imports: {
+    env: { memory: new WebAssembly.Memory({ initial: 1 }) }
+  },
+  exports: {
+    dec: () => 0,
+    end: () => 0
+  },
+  compile: {
+    switches: ['-msimd128', '-Wl,-z,stack-size=0', '-Wl,--stack-first']
+  },
+  code: `
+    #include <wasm_simd128.h>
+    typedef struct {
+      unsigned int wp;
+      unsigned int sp;
+      unsigned int dp;
+      unsigned int e_size;
+      unsigned int dummy[4];
+      unsigned char data[0];
+    } State;
+
+    unsigned int *D0 = (unsigned int *) ${P32.D0 * 4};
+    unsigned int *D1 = (unsigned int *) ${P32.D1 * 4};
+    unsigned int *D2 = (unsigned int *) ${P32.D2 * 4};
+    unsigned int *D3 = (unsigned int *) ${P32.D3 * 4};
+    State *state = (State *) ${P32.STATE * 4};
+
+    #define packed_byte(x) wasm_i8x16_splat((char) x)
+    #define packed_dword(x) wasm_i32x4_splat(x)
+    #define masked(x, mask) wasm_v128_and(x, wasm_i32x4_splat(mask))
+
+    __attribute__((noinline)) int dec() {
+      unsigned int nsp = (state->wp - 1) & ~3;
+      unsigned char *src = state->data + state->sp;
+      unsigned char *end = state->data + nsp;
+      unsigned char *dst = state->data + state->dp;
+      unsigned int error = 0;
+
+      v128_t err = wasm_i8x16_splat(0);
+      unsigned char *end16 = state->data + (nsp & ~15);
+      while (src < end16) {
+        v128_t data = wasm_v128_load((v128_t *) src);
+
+        // wasm-simd rewrite of http://0x80.pl/notesen/2016-01-17-sse-base64-decoding.html#vector-lookup-pshufb
+        const v128_t higher_nibble = wasm_u32x4_shr(data, 4) & packed_byte(0x0f);
+        const char linv = 1;
+        const char hinv = 0;
+
+        const v128_t lower_bound_LUT = wasm_i8x16_make(
+          // order: 0 1 2 3 4 5 6 7 8 9 a b c d e f
+          linv, linv, 0x2b, 0x30,
+          0x41, 0x50, 0x61, 0x70,
+          linv, linv, linv, linv,
+          linv, linv, linv, linv
+        );
+        const v128_t upper_bound_LUT = wasm_i8x16_make(
+          // order: 0 1 2 3 4 5 6 7 8 9 a b c d e f
+          hinv, hinv, 0x2b, 0x39,
+          0x4f, 0x5a, 0x6f, 0x7a,
+          hinv, hinv, hinv, hinv,
+          hinv, hinv, hinv, hinv
+        );
+        // the difference between the shift and lower bound
+        const v128_t shift_LUT = wasm_i8x16_make(
+          // order: 0 1 2 3 4 5 6 7 8 9 a b c d e f
+          0x00,        0x00,        0x3e - 0x2b, 0x34 - 0x30,
+          0x00 - 0x41, 0x0f - 0x50, 0x1a - 0x61, 0x29 - 0x70,
+          0x00,        0x00,        0x00,        0x00,
+          0x00,        0x00,        0x00,        0x00
+        );
+
+        const v128_t upper_bound = wasm_i8x16_swizzle(upper_bound_LUT, higher_nibble);
+        const v128_t lower_bound = wasm_i8x16_swizzle(lower_bound_LUT, higher_nibble);
+
+        const v128_t below = wasm_i8x16_lt(data, lower_bound);
+        const v128_t above = wasm_i8x16_gt(data, upper_bound);
+        const v128_t eq_2f = wasm_i8x16_eq(data, packed_byte(0x2f));
+
+        // in_range = not (below or above) or eq_2f
+        // outside  = not in_range = below or above and not eq_2f (from deMorgan law)
+        const v128_t outside = wasm_v128_andnot(eq_2f, above | below);
+        err = wasm_v128_or(err, outside);
+
+        const v128_t shift  = wasm_i8x16_swizzle(shift_LUT, higher_nibble);
+        const v128_t t0     = wasm_i8x16_add(data, shift);
+        v128_t v = wasm_i8x16_add(t0, wasm_v128_and(eq_2f, packed_byte(-3)));
+
+        // pack bytes
+        const v128_t ca = masked(v, 0x003f003f);
+        const v128_t db = masked(v, 0x3f003f00);
+        const v128_t t00 = wasm_v128_or(wasm_u32x4_shr(db, 8), wasm_i32x4_shl(ca, 6));
+        v128_t res = wasm_v128_or(wasm_u32x4_shr(t00, 16), wasm_i32x4_shl(t00, 12));
+        res = wasm_i8x16_swizzle(res, wasm_i8x16_const(2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12, 16, 16, 16, 16));
+
+        wasm_v128_store((v128_t *) dst, res);
+        dst += 12;
+        src += 16;
+      }
+      if (wasm_i8x16_bitmask(err) != 0) return 1;
+
+      // operate on 4-byte blocks
+      while (src < end) {
+        error |= *((unsigned int *) dst) = D0[src[0]] | D1[src[1]] | D2[src[2]] | D3[src[3]];
+        dst += 3;
+        src += 4;
+      }
+      if (error >> 24) return 1;
+      state->sp = nsp;
+      state->dp = dst - state->data;
+      return 0;
+    }
+
+    int end() {
+      int rem = state->wp - state->sp;
+      if (rem > 4 && dec()) return 1;
+      rem = state->wp - state->sp;
+      if (rem < 2) return 1;
+
+      unsigned char *src = state->data + state->sp;
+      if (rem == 4) {
+        if (src[3] == 61) rem--;
+        if (src[2] == 61) rem--;
+      }
+      unsigned int accu = D0[src[0]] | D1[src[1]];
+      int dp = 1;
+      if (rem > 2) {
+        accu |= D2[src[2]];
+        dp++;
+        if (rem == 4) {
+          accu |= D3[src[3]];
+          dp++;
+        }
+      }
+      if (accu >> 24) return 1;
+      *((unsigned int *) (state->data + state->dp)) = accu;
+      state->dp += dp;
+      return 0;
+    }
+    `
+});
+*/
 
 // FIXME: currently broken in inwasm
 type WasmDecodeType = ReturnType<typeof wasmDecode>;
@@ -304,7 +300,7 @@ export default class Base64Decoder {
   private _inst!: WasmDecodeType;
   private _mem!: WebAssembly.Memory;
 
-  constructor(public keepSize: number) {}
+  constructor(public keepSize: number) { }
 
   /**
    * Currently decoded bytes (borrowed).

--- a/src/base64/Base64Encoder.wasm.ts
+++ b/src/base64/Base64Encoder.wasm.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 The xterm.js authors. All rights reserved.
  * @license MIT
  */
-import { InWasm, IWasmInstance, OutputMode, OutputType, ExtractDefinition } from 'inwasm';
+import { InWasm, OutputMode, OutputType } from 'inwasm';
 
 const enum P8 {
   LUT_P = 1024,
@@ -88,7 +88,7 @@ const wasmEncode = InWasm({
     `
 });
 
-type B64Encode = ExtractDefinition<ReturnType<typeof wasmEncode>>;
+type WasmEncodeType = ReturnType<typeof wasmEncode>;
 
 // base64 map
 const MAP = new Uint8Array(
@@ -117,7 +117,7 @@ for (let i = 0; i < MAP.length; ++i) {
  * roughly doubling the throughput compared to a simple scalar implementation.
  */
 export default class Base64Encoder {
-  private _inst!: IWasmInstance<B64Encode>;
+  private _inst!: WasmEncodeType;
   private _mem!: WebAssembly.Memory;
   private _d!: Uint8Array;
 

--- a/src/base64/base64.benchmark.ts
+++ b/src/base64/base64.benchmark.ts
@@ -52,28 +52,28 @@ perfContext('Base64 - decode', () => {
   perfContext('Base64Decoder', () => {
     new ThroughputRuntimeCase('256', () => {
       dec.init(192);
-      dec.put(b256, 0, b256.length);
+      dec.put(b256);
       dec.end();
       return { payloadSize: b256.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
     new ThroughputRuntimeCase('4096', () => {
       dec.init(3072);
-      dec.put(b4096, 0, b4096.length);
+      dec.put(b4096);
       dec.end();
       return { payloadSize: b4096.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
     new ThroughputRuntimeCase('65536', () => {
       dec.init(49152);
-      dec.put(b65536, 0, b65536.length);
+      dec.put(b65536);
       dec.end();
       return { payloadSize: b65536.length };
     }, { repeat: RUNS }).showAverageThroughput();
 
     new ThroughputRuntimeCase('1048576', () => {
       dec.init(786432);
-      dec.put(b1M, 0, b1M.length);
+      dec.put(b1M);
       dec.end();
       return { payloadSize: b1M.length };
     }, { repeat: RUNS }).showAverageThroughput();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
-import Base64Decoder from "./base64/Base64Decoder.wasm";
+/**
+ * Copyright (c) 2023 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
 
-export { Base64Decoder };
+import Base64Decoder from "./base64/Base64Decoder.wasm";
+import Base64Encoder from "./base64/Base64Encoder.wasm";
+
+export { Base64Decoder, Base64Encoder };

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,9 +54,9 @@
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
 "@types/node@*", "@types/node@^20.5.4":
-  version "20.5.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.4.tgz#4666fb40f9974d60c53c4ff554315860ba4feab8"
-  integrity sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==
+  version "20.5.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
+  integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
 "@types/node@^12.12.37":
   version "12.20.55"
@@ -804,9 +804,9 @@ typescript@^4.2.3:
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@^5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 wabt@^1.0.32:
   version "1.0.32"


### PR DESCRIPTION
This is mostly interface and code cleanup.

Important changes (needs follow-up changes in caller code):
- interface changed on `Base64Decoder.put`
- removed final byte size measuring from `Base64Decoder.end` (to be done on caller side now) 